### PR TITLE
Rename of parameter from account_id to site_name

### DIFF
--- a/.bluemix/pagerduty.yml
+++ b/.bluemix/pagerduty.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  account_id: ""
+  site_name: ""
   api_key: ""
   service_name: ""
   user_email: ""


### PR DESCRIPTION
See details in Defect 54585: PagerDuty: Unclear about PagerDuty information in integration configuration
https://hub.jazz.net/ccm09/web/projects/idsorg%20%7C%20One%20Ring%20Track%20and%20Plan#action=com.ibm.team.workitem.viewWorkItem&id=54585