### PR TITLE
Task 60190: remove references to no longer needed PagerDuty 'site_name'

### DIFF
--- a/.bluemix/pagerduty.yml
+++ b/.bluemix/pagerduty.yml
@@ -1,6 +1,5 @@
 ---
 parameters:
-  site_name: ""
   api_key: ""
   service_name: ""
   user_email: ""


### PR DESCRIPTION
otc-pagerduty-broker no longer needs the 'site_name' parameter when configuring a service instance. This pull request removes all references to 'site_name' in toolchain-demo.