### PR TITLE
Task 61349: Remove CF region & org from template (master)

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -134,12 +134,6 @@ deploy:
     $ref: deploy.json
   service-category: pipeline
   parameters:
-    dev-region: "{{region}}"
-    qa-region: "{{region}}"
-    prod-region: "{{region}}"
-    dev-organization: "{{organization}}"
-    qa-organization: "{{organization}}"
-    prod-organization: "{{organization}}"
     dev-space: dev
     qa-space: qa
     prod-space: prod


### PR DESCRIPTION
Remove `{{region}}, {{organization}}` mustache templates.
The CF helper supplies initial values for these fields instead.