### PR TITLE
Task 61349: Remove CF region & org from template (dedicated-cio)

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -112,12 +112,6 @@ deploy:
     $ref: deploy.json
   service-category: pipeline
   parameters:
-    dev-region: "{{region}}"
-    qa-region: "{{region}}"
-    prod-region: "{{region}}"
-    dev-organization: "{{organization}}"
-    qa-organization: "{{organization}}"
-    prod-organization: "{{organization}}"
     dev-space: dev
     qa-space: qa
     prod-space: prod


### PR DESCRIPTION
Remove `{{region}}` and `{{organization}}` mustache templates.
The CF helper supplies initial values for these fields instead.