### PR TITLE
Removed the --force flag from grunt fvt calls.

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -100,7 +100,7 @@ stages:
       if [ -f $GRUNTFILE ]; then
         npm install -g npm@3.7.2 ### work around default npm 2.1.1 instability
         npm install
-        grunt dev-fvt --no-color -f --gruntfile $GRUNTFILE --base .
+        grunt dev-fvt --no-color --gruntfile $GRUNTFILE --base .
       else
         echo "$GRUNTFILE not found."
       fi
@@ -196,9 +196,9 @@ stages:
         npm install
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
-          grunt test_fake -f --gruntfile $GRUNTFILE --base .
+          grunt test_fake --gruntfile $GRUNTFILE --base .
         else
-          grunt test_real -f --gruntfile $GRUNTFILE --base .
+          grunt test_real --gruntfile $GRUNTFILE --base .
         fi
       else
         echo "$GRUNTFILE not found."

--- a/.bluemix/order-api.pipeline.yml
+++ b/.bluemix/order-api.pipeline.yml
@@ -152,9 +152,9 @@ stages:
         npm install
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
-          grunt test_fake -f --gruntfile $GRUNTFILE --base .
+          grunt test_fake --gruntfile $GRUNTFILE --base .
         else
-          grunt test_real -f --gruntfile $GRUNTFILE --base .
+          grunt test_real --gruntfile $GRUNTFILE --base .
         fi
       else
         echo "$GRUNTFILE not found."

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -149,9 +149,9 @@ stages:
         npm install
         echo $APP_URL | grep "stage1"
         if [ $? -eq 0 ]; then
-          grunt test_fake -f --gruntfile $GRUNTFILE --base .
+          grunt test_fake --gruntfile $GRUNTFILE --base .
         else
-          grunt test_real -f --gruntfile $GRUNTFILE --base .
+          grunt test_real --gruntfile $GRUNTFILE --base .
         fi
       else
         echo "$GRUNTFILE not found."


### PR DESCRIPTION
Removed the --force flag from grunt fvt calls. This will allow the jobs to fail if issues occur. The --force flag was allowing the job to pass even though errors were present.